### PR TITLE
customize the build for KA

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,25 @@
 {
   "build/react-motion.js": {
-    "bundled": 77059,
-    "minified": 22596,
-    "gzipped": 6616
+    "bundled": 44046,
+    "minified": 13460,
+    "gzipped": 4657
   },
   "build/react-motion.min.js": {
-    "bundled": 52481,
-    "minified": 15210,
-    "gzipped": 4446
+    "bundled": 20576,
+    "minified": 6686,
+    "gzipped": 2643
   },
   "lib/react-motion.esm.js": {
-    "bundled": 43290,
-    "minified": 14594,
-    "gzipped": 3583,
+    "bundled": 11631,
+    "minified": 4310,
+    "gzipped": 1547,
     "treeshaked": {
       "rollup": {
-        "code": 6381,
+        "code": 416,
         "import_statements": 196
       },
       "webpack": {
-        "code": 7588
+        "code": 1593
       }
     }
   }

--- a/src/react-motion.js
+++ b/src/react-motion.js
@@ -1,10 +1,11 @@
 /* @flow */
 export { default as Motion } from './Motion';
-export { default as StaggeredMotion } from './StaggeredMotion';
-export { default as TransitionMotion } from './TransitionMotion';
+// export { default as StaggeredMotion } from './StaggeredMotion';
+// TODO(FEI-3195): enable this once the ADR has been approved
+// export { default as TransitionMotion } from './TransitionMotion';
 export { default as spring } from './spring';
 export { default as presets } from './presets';
-export { default as stripStyle } from './stripStyle';
+// export { default as stripStyle } from './stripStyle';
 
 // deprecated, dummy warning function
-export { default as reorderKeys } from './reorderKeys';
+// export { default as reorderKeys } from './reorderKeys';


### PR DESCRIPTION
We only include those things that we using in webapp. In the future we may want to include TransitionMotion in order to replace react-transition-group, but we haven't made that decision yet.

I ran `npm run prepublishOnly` to generate build files.

Once this is merged, I think we should add this to package.json using a URL+SHA like we do for react-loadable instead of checking the files like we do now.